### PR TITLE
Add ability to change gridColumns per Container

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -50,7 +50,8 @@ declare module 'react-grid-system' {
         xl?: boolean
         fluid?: boolean,
         style?: object,
-        component?: () => string | string
+        component?: () => string | string,
+        gridColumns?: number,
     }
 
     type RowProps = React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> & {

--- a/src/grid/Col/index.jsx
+++ b/src/grid/Col/index.jsx
@@ -1,9 +1,9 @@
 import React, { createElement } from 'react';
 import PropTypes from 'prop-types';
 import getStyle from './style';
-import { getConfiguration } from '../../config';
 import { GutterWidthContext } from '../Row';
 import ScreenClassResolver from '../../context/ScreenClassResolver';
+import { CustomGridColumnsContext } from '../Container';
 
 export default class Col extends React.PureComponent {
   static propTypes = {
@@ -105,7 +105,7 @@ export default class Col extends React.PureComponent {
     component: 'div',
   };
 
-  renderCol = (gutterWidth, screenClass) => {
+  renderCol = (gutterWidth, screenClass, gridColumns) => {
     const {
       children,
       xs,
@@ -135,7 +135,7 @@ export default class Col extends React.PureComponent {
       debug,
       screenClass,
       gutterWidth,
-      gridColumns: getConfiguration().gridColumns,
+      gridColumns,
       moreStyle: style,
     });
     return createElement(component, { style: theStyle, ...otherProps, children });
@@ -144,9 +144,13 @@ export default class Col extends React.PureComponent {
   render = () => (
     <ScreenClassResolver>
       {screenClass => (
-        <GutterWidthContext.Consumer>
-          {gutterWidth => this.renderCol(gutterWidth, screenClass)}
-        </GutterWidthContext.Consumer>
+        <CustomGridColumnsContext.Consumer>
+          {gridColumns => (
+            <GutterWidthContext.Consumer>
+              {gutterWidth => this.renderCol(gutterWidth, screenClass, gridColumns)}
+            </GutterWidthContext.Consumer>
+          )}
+        </CustomGridColumnsContext.Consumer>
       )}
     </ScreenClassResolver>
   );

--- a/src/grid/Container/index.jsx
+++ b/src/grid/Container/index.jsx
@@ -4,6 +4,8 @@ import getStyle, { getAfterStyle } from './style';
 import { getConfiguration } from '../../config';
 import ScreenClassResolver from '../../context/ScreenClassResolver';
 
+export const CustomGridColumnsContext = React.createContext(getConfiguration().gridColumns);
+
 export default class Container extends React.PureComponent {
   static propTypes = {
     /**
@@ -47,6 +49,10 @@ export default class Container extends React.PureComponent {
      * Use your own component
      */
     component: PropTypes.elementType,
+    /**
+     * Use your own gridColumns value for Container
+     */
+    gridColumns: PropTypes.number,
   };
 
   static defaultProps = {
@@ -58,11 +64,12 @@ export default class Container extends React.PureComponent {
     xl: false,
     style: {},
     component: 'div',
+    gridColumns: getConfiguration().gridColumns,
   };
 
   render() {
     const {
-      children, fluid, xs, sm, md, lg, xl, style, component, ...otherProps
+      children, fluid, xs, sm, md, lg, xl, style, component, gridColumns, ...otherProps
     } = this.props;
 
     return (
@@ -85,8 +92,10 @@ export default class Container extends React.PureComponent {
             ...otherProps,
           },
           <React.Fragment>
-            {children}
-            <span style={getAfterStyle()} />
+            <CustomGridColumnsContext.Provider value={gridColumns}>
+              {children}
+              <span style={getAfterStyle()} />
+            </CustomGridColumnsContext.Provider>
           </React.Fragment>,
         )
         }

--- a/src/grid/Readme.md
+++ b/src/grid/Readme.md
@@ -247,3 +247,24 @@ Resize your browser or load on different devices to test the grid system.
   </Row>
 </Container>
 ```
+
+You can define a custom grid columns value to specific Container
+
+### Example: Custom grid columns param
+
+```
+<Container fluid style={{ lineHeight: '32px' }} gridColumns={15}>
+  <Row debug>
+    <Col lg={10} debug>1 of 2</Col>
+    <Col lg={5} debug>2 of 2</Col>
+  </Row>
+  <br />
+  <Row debug>
+    <Col debug>1 of 3</Col>
+    <Col debug>2 of 3</Col>
+    <Col debug>3 of 3</Col>
+  </Row>
+</Container>
+```
+
+


### PR DESCRIPTION
Sometimes it's convenient to change gridColumns value on Container rather then per project globally, if it make sense I have a small solution of this problem based on the same idea with a gutter context but Provider is created on Container level and consumes gridColumn on Column level, if there is no gridColumn prop specified in Container the default value from config is applied.
Example:
```
<Container fluid style={{ lineHeight: '32px' }} gridColumns={13}>
  <Row debug>
    <Col lg={7} debug>1 of 2</Col>
    <Col lg={6} debug>2 of 2</Col>
  </Row>
</Container>
```
Row consumes value from nearest Container Provider.