### PR TITLE
Force render mismatches style between the server and client

### DIFF
--- a/src/grid/Col/index.jsx
+++ b/src/grid/Col/index.jsx
@@ -6,6 +6,15 @@ import { GutterWidthContext } from '../Row';
 import ScreenClassResolver from '../../context/ScreenClassResolver';
 
 export default class Col extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = { hasMounted: false };
+  }
+
+  componentDidMount() {
+    this.setState({ hasMounted: true });
+  }
+
   renderCol = (gutterWidth, screenClass) => {
     const {
       children,
@@ -22,23 +31,26 @@ export default class Col extends React.PureComponent {
       component,
       ...otherProps
     } = this.props;
-    const theStyle = getStyle({
-      width: {
-        xs,
-        sm,
-        md,
-        lg,
-        xl,
-      },
-      offset,
-      pull,
-      push,
-      debug,
-      screenClass,
-      gutterWidth,
-      gridColumns: getConfiguration().gridColumns,
-      moreStyle: style,
-    });
+    const { hasMounted } = this.state;
+    const theStyle = hasMounted
+      ? getStyle({
+        width: {
+          xs,
+          sm,
+          md,
+          lg,
+          xl,
+        },
+        offset,
+        pull,
+        push,
+        debug,
+        screenClass,
+        gutterWidth,
+        gridColumns: getConfiguration().gridColumns,
+        moreStyle: style,
+      })
+      : undefined;
     return createElement(component, { style: theStyle, ...otherProps, children });
   };
 
@@ -61,38 +73,23 @@ Col.propTypes = {
   /**
    * The width of the column for screenclass `xs`, either a number between 0 and 12, or "content"
    */
-  xs: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.oneOf(['content']),
-  ]),
+  xs: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['content'])]),
   /**
    * The width of the column for screenclass `sm`, either a number between 0 and 12, or "content"
    */
-  sm: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.oneOf(['content']),
-  ]),
+  sm: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['content'])]),
   /**
    * The width of the column for screenclass `md`, either a number between 0 and 12, or "content"
    */
-  md: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.oneOf(['content']),
-  ]),
+  md: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['content'])]),
   /**
    * The width of the column for screenclass `lg`, either a number between 0 and 12, or "content"
    */
-  lg: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.oneOf(['content']),
-  ]),
+  lg: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['content'])]),
   /**
    * The width of the column for screenclass `xl`, either a number between 0 and 12, or "content"
    */
-  xl: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.oneOf(['content']),
-  ]),
+  xl: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['content'])]),
   /**
    * The offset of this column for all screenclasses
    */


### PR DESCRIPTION
Gatsby renders the page without knowing the viewport of the device it displays towards.

We can detect and set `defaultScreenClass` config on the client-side (https://github.com/sealninja/react-ssr-example/blob/master/client.js), but React expects that the rendered content is identical between the server and the client. It can patch up differences in text content, but not object (https://reactjs.org/docs/react-dom.html#hydrate). Therefore the `style` mismatch between the server-side and client-side will not get re-render.

One possible solution that I have found is doing a two-pass rendering https://github.com/facebook/react/issues/8017#issuecomment-256351955. Doing so will introduce a `flashing` effect when reloading the page. We can overcome this issue by introducing a small splash screen long enough to load the correct viewport (https://stackoverflow.com/questions/57188179/show-overlay-only-once-on-page-entrance-not-route-change-howto).