### PR TITLE
replaced shorthand with non-shorthand props to avoid warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-grid-system",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "description": "A powerful Bootstrap-like responsive grid system for React.",
   "main": "./build/index.js",
   "scripts": {

--- a/src/grid/Col/style.js
+++ b/src/grid/Col/style.js
@@ -63,7 +63,9 @@ export default ({
   }
 
   if (forceWidth) {
-    styles.flex = 'unset';
+    styles.flexBasis = 'unset';
+    styles.flexGrow = 'unset';
+    styles.flexShrink = 'unset';
     styles.width = forceWidth;
   }
 


### PR DESCRIPTION
Hi,
I'm using your module, and I have a warning during the snapshots generation in Storybook v5.3.19:

**Warning: Updating a style property during rerender (flexBasis) when a conflicting property is set (flex) can lead to styling bugs. To avoid this, don't mix shorthand and non-shorthand properties for the same value; instead, replace the shorthand with separate values.**

This PR will fix it.

I just replaced the shorthand reset with the non-shorthand props.