### PR TITLE
Support React Native

### DIFF
--- a/src/context/ScreenClassProvider/index.js
+++ b/src/context/ScreenClassProvider/index.js
@@ -2,6 +2,7 @@ import React, { useRef, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useScreenClass } from '../../utils';
 import { getConfiguration } from '../../config';
+import { Div } from '../../primitives'
 
 export const NO_PROVIDER_FLAG = 'NO_PROVIDER_FLAG';
 
@@ -20,7 +21,7 @@ const ScreenClassProvider = ({ useOwnWidth, children, fallbackScreenClass }) => 
   return (
     <ScreenClassContext.Provider value={screenClass}>
       {useOwnWidth
-        ? <div ref={useOwnWidth ? screenClassRef : null}>{children}</div>
+        ? <Div ref={useOwnWidth ? screenClassRef : null}>{children}</Div>
         : <>{children}</>}
     </ScreenClassContext.Provider>
   );

--- a/src/grid/Col/index.js
+++ b/src/grid/Col/index.js
@@ -4,6 +4,7 @@ import getStyle from './style';
 import { getConfiguration } from '../../config';
 import { GutterWidthContext } from '../Row';
 import ScreenClassResolver from '../../context/ScreenClassResolver';
+import { Div } from '../../primitives'
 
 const Col = ({
   children,
@@ -167,7 +168,7 @@ Col.defaultProps = {
   pull: {},
   style: {},
   debug: false,
-  component: 'div',
+  component: Div,
 };
 
 export default Col;

--- a/src/grid/Col/style.js
+++ b/src/grid/Col/style.js
@@ -22,17 +22,17 @@ export default ({
 }) => {
   const styles = {
     boxSizing: 'border-box',
-    minHeight: '1px',
+    minHeight: 1,
     position: 'relative',
-    paddingLeft: `${gutterWidth / 2}px`,
-    paddingRight: `${gutterWidth / 2}px`,
+    paddingLeft: gutterWidth / 2,
+    paddingRight: gutterWidth / 2,
     width: '100%',
   };
 
   if (debug) {
     styles.outline = '1px solid silver';
     styles.background = 'rgba(0,0,0,.05)';
-    styles.lineHeight = '32px';
+    styles.lineHeight = 32;
   }
 
   styles.flexBasis = '100%';

--- a/src/grid/Container/index.js
+++ b/src/grid/Container/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import getStyle, { getAfterStyle } from './style';
 import { getConfiguration } from '../../config';
 import ScreenClassResolver from '../../context/ScreenClassResolver';
+import { Div, Span } from '../../primitives'
 
 const Container = ({
   children,
@@ -38,7 +39,7 @@ const Container = ({
       },
       <>
         {children}
-        <span style={getAfterStyle()} />
+        <Span style={getAfterStyle()} />
       </>,
     )}
   </ScreenClassResolver>
@@ -102,7 +103,7 @@ Container.defaultProps = {
   xl: false,
   xxl: false,
   style: {},
-  component: 'div',
+  component: Div,
 };
 
 export default Container;

--- a/src/grid/Container/style.js
+++ b/src/grid/Container/style.js
@@ -16,8 +16,8 @@ export default ({
     position: 'relative',
     marginLeft: 'auto',
     marginRight: 'auto',
-    paddingLeft: `${gutterWidth / 2}px`,
-    paddingRight: `${gutterWidth / 2}px`,
+    paddingLeft: gutterWidth / 2,
+    paddingRight: gutterWidth / 2,
   };
 
   if (fluid && (!sm && !md && !lg && !xl)) {
@@ -25,23 +25,23 @@ export default ({
   }
 
   if (screenClass === 'sm' && containerWidths[0] && !sm && !xs) {
-    styles.maxWidth = `${containerWidths[0]}px`;
+    styles.maxWidth = containerWidths[0];
   }
 
   if (screenClass === 'md' && containerWidths[1] && !md) {
-    styles.maxWidth = `${containerWidths[1]}px`;
+    styles.maxWidth = containerWidths[1];
   }
 
   if (screenClass === 'lg' && containerWidths[2] && !lg) {
-    styles.maxWidth = `${containerWidths[2]}px`;
+    styles.maxWidth = containerWidths[2];
   }
 
   if (screenClass === 'xl' && containerWidths[3] && !xl) {
-    styles.maxWidth = `${containerWidths[3]}px`;
+    styles.maxWidth = containerWidths[3];
   }
 
   if (screenClass === 'xxl' && containerWidths[4] && !xxl) {
-    styles.maxWidth = `${containerWidths[4]}px`;
+    styles.maxWidth = containerWidths[4];
   }
 
   return { ...styles, ...moreStyle };

--- a/src/grid/Row/index.js
+++ b/src/grid/Row/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { getConfiguration } from '../../config';
 import getStyle from './style';
+import { Div } from '../../primitives'
 
 export const GutterWidthContext = React.createContext(false);
 
@@ -93,7 +94,7 @@ Row.defaultProps = {
   gutterWidth: null,
   style: {},
   debug: false,
-  component: 'div',
+  component: Div,
   nowrap: false,
 };
 

--- a/src/grid/Row/style.js
+++ b/src/grid/Row/style.js
@@ -17,8 +17,8 @@ export default ({
   if (justify === 'inherit') justifyContent = 'inherit';
 
   const styles = {
-    marginLeft: `-${gutterWidth / 2}px`,
-    marginRight: `-${gutterWidth / 2}px`,
+    marginLeft: -gutterWidth / 2,
+    marginRight: -gutterWidth / 2,
     display: 'flex',
     flexWrap: nowrap ? 'nowrap' : 'wrap',
     flexGrow: 0,

--- a/src/primitives/Div/index.js
+++ b/src/primitives/Div/index.js
@@ -1,0 +1,1 @@
+export default 'div'

--- a/src/primitives/Div/index.native.js
+++ b/src/primitives/Div/index.native.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { View } from 'react-native'
+
+export default ({
+  children,
+  style,
+  ...rest
+}) => (
+  <View
+    style={[{ flexDirection: 'row' }, style]}
+    {...rest}
+  >
+    {children}
+  </View>
+)

--- a/src/primitives/Span/index.js
+++ b/src/primitives/Span/index.js
@@ -1,0 +1,1 @@
+export default 'span'

--- a/src/primitives/Span/index.native.js
+++ b/src/primitives/Span/index.native.js
@@ -1,0 +1,3 @@
+import { View } from 'react-native'
+
+export default View

--- a/src/primitives/Window/index.js
+++ b/src/primitives/Window/index.js
@@ -1,0 +1,1 @@
+export default window

--- a/src/primitives/Window/index.native.js
+++ b/src/primitives/Window/index.native.js
@@ -1,0 +1,25 @@
+import { Dimensions } from 'react-native'
+
+const WindowRef = { current: null }
+
+const { width, height } = Dimensions.get('window')
+
+WindowRef.current = {
+  innerWidth: width,
+  innerHeight: height,
+  addEventListener: (___, callback) => {
+    Dimensions.addEventListener('change', ({ window }) => {
+      const {
+        current: Window
+      } = WindowRef
+      Window.innerWidth = window.width
+      Window.innerHeight = window.height
+      callback()
+    })
+  },
+  removeEventListener: (___, callback) => {
+    Dimensions.removeEventListener('change', callback)
+  },
+}
+
+export default WindowRef.current

--- a/src/primitives/index.js
+++ b/src/primitives/index.js
@@ -1,0 +1,11 @@
+export {
+  default as Div,
+} from './Div'
+
+export {
+  default as Span,
+} from './Span'
+
+export {
+  default as Window,
+} from './Window'

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,13 +2,14 @@
 
 import { useState, useEffect } from 'react';
 import { getConfiguration } from './config';
+import { Window } from './primitives'
 
 const getViewPort = (source) => {
   if (source && source.current && source.current.clientWidth) {
     return source.current.clientWidth;
   }
-  if (typeof window !== 'undefined' && window.innerWidth) {
-    return window.innerWidth;
+  if (typeof Window !== 'undefined' && Window.innerWidth) {
+    return Window.innerWidth;
   }
   return null;
 };
@@ -48,10 +49,10 @@ export const useScreenClass = (source, fallbackScreenClass) => {
   useEffect(() => {
     const handleWindowResized = () => setScreenClass(getScreenClass());
 
-    window.addEventListener('resize', handleWindowResized, false);
+    Window.addEventListener('resize', handleWindowResized, false);
 
     return () => {
-      window.removeEventListener('resize', handleWindowResized, false);
+      Window.removeEventListener('resize', handleWindowResized, false);
     };
   }, []);
 


### PR DESCRIPTION
I think the library is really nice. I want to use with react-native for mobile apps. To work with react-native, I added react-native primitives with files which are ending with .native.js . When react-native bundler is running, it will understand which file it should be used. Here is the things which I've changed in short: 

- Add View and Dimensions API to use instead of 'div', 'span', window
- Change defaultProps.component with new primitives
- Change style measurement strings with numbers (react-native does not support string px measurements ("10px"), it converts number values automatically. Also react automatically appends "px" for number values on web application. So it will work on both platform.)
- Change window with Window ( I added just few functions which the library uses )

I hope you find it useful. 