### PR TITLE
Fix: fluid xs makes Container max width on all screen sizes

### DIFF
--- a/src/grid/Container/style.js
+++ b/src/grid/Container/style.js
@@ -20,11 +20,15 @@ export default ({
     paddingRight: gutterWidth / 2,
   };
 
-  if (fluid && (!sm && !md && !lg && !xl)) {
+  if (fluid && !xs && !sm && !md && !lg && !xl) {
     return { ...styles, ...moreStyle };
   }
 
-  if (screenClass === 'sm' && containerWidths[0] && !sm && !xs) {
+  if (screenClass === 'xs' && containerWidths[0] && !xs) {
+    styles.maxWidth = containerWidths[0];
+  }
+
+  if (screenClass === 'sm' && containerWidths[0] && !sm) {
     styles.maxWidth = containerWidths[0];
   }
 


### PR DESCRIPTION
```js
if (fluid && (!sm && !md && !lg && !xl)) {    
  return { ...styles, ...moreStyle };  
}
```

When we use `<Container fluid xs>`, the above code block evaluates to `true` and returns styles that don't contain max-width regardless of the screen size.

This change adds `!xs` to the `if` condition so that this condition evaluates to `false` when `fluid xs` prop is used on `Container`. Also separated the `xs` and `sm` max width so `sm` max-width continues to work when using `xs`.

Fixes #177 