### PR TITLE
Improve Types for React v18 Compatibility

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -42,14 +42,13 @@ declare module 'react-grid-system' {
         gutterWidth?: number
     }
 
-    type ClearFixProps = ScreenClassMap<boolean>;
-    type HiddenProps = ScreenClassMap<boolean>;
+    type ClearFixProps = { children: React.ReactNode } & ScreenClassMap<boolean>;
+    type VisibleProps = { children: React.ReactNode } & ScreenClassMap<boolean>;
+    type HiddenProps = { children: React.ReactNode } & ScreenClassMap<boolean>;
 
     type ScreenClassRenderProps = {
-        render?: Function
+        render?: (screenClass: ScreenClass) => Exclude<React.ReactNode, undefined>
     }
-
-    type VisibleProps = ScreenClassMap<boolean>;
 
     type Configuration = {
         breakpoints?: Array<number>,


### PR DESCRIPTION
This PR includes a few type fixes for React v18 types. Those newer types don't include children by default, so they must be named explicitly or one gets type errors like the following:

```
index.tsx:583:24 - error TS2769: No overload matches this call.
  Overload 1 of 2, '(props: Partial<Record<ScreenClass, boolean>> | Readonly<Partial<Record<ScreenClass, boolean>>>): Hidden', gave the following error.
    Type '{ children: Element; xs: true; sm: true; md: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Hidden> & Readonly<Partial<Record<ScreenClass, boolean>>>'.
      Property 'children' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Hidden> & Readonly<Partial<Record<ScreenClass, boolean>>>'.
  Overload 2 of 2, '(props: Partial<Record<ScreenClass, boolean>>, context: any): Hidden', gave the following error.
    Type '{ children: Element; xs: true; sm: true; md: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Hidden> & Readonly<Partial<Record<ScreenClass, boolean>>>'.
      Property 'children' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Hidden> & Readonly<Partial<Record<ScreenClass, boolean>>>'.

583                       <Hidden xs sm md>
```

This change should also be backwards compact with 16/17 types.