### PR TITLE
Refactor: Replace defaultProps with Default Function Parameters

### DIFF
--- a/src/context/ScreenClassProvider/index.js
+++ b/src/context/ScreenClassProvider/index.js
@@ -1,28 +1,39 @@
-import React, { useRef, useState, useEffect } from 'react';
-import PropTypes from 'prop-types';
-import { useScreenClass } from '../../utils';
-import { getConfiguration } from '../../config';
-import { Div } from '../../primitives'
+import React, { useRef, useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import { useScreenClass } from "../../utils";
+import { getConfiguration } from "../../config";
+import { Div } from "../../primitives";
 
-export const NO_PROVIDER_FLAG = 'NO_PROVIDER_FLAG';
+export const NO_PROVIDER_FLAG = "NO_PROVIDER_FLAG";
 
 export const ScreenClassContext = React.createContext(NO_PROVIDER_FLAG);
 
-const ScreenClassProvider = ({ useOwnWidth, children, fallbackScreenClass }) => {
+const ScreenClassProvider = ({
+  useOwnWidth = false,
+  children,
+  fallbackScreenClass = null,
+}) => {
   const screenClassRef = useRef();
   const [mounted, setMounted] = useState(false);
-  const detectedScreenClass = useScreenClass(screenClassRef, fallbackScreenClass);
+  const detectedScreenClass = useScreenClass(
+    screenClassRef,
+    fallbackScreenClass
+  );
   const { defaultScreenClass } = getConfiguration();
 
-  const screenClass = mounted ? detectedScreenClass : (fallbackScreenClass || defaultScreenClass);
+  const screenClass = mounted
+    ? detectedScreenClass
+    : fallbackScreenClass || defaultScreenClass;
 
   useEffect(() => setMounted(true), []);
 
   return (
     <ScreenClassContext.Provider value={screenClass}>
-      {useOwnWidth
-        ? <Div ref={useOwnWidth ? screenClassRef : null}>{children}</Div>
-        : <>{children}</>}
+      {useOwnWidth ? (
+        <Div ref={useOwnWidth ? screenClassRef : null}>{children}</Div>
+      ) : (
+        <>{children}</>
+      )}
     </ScreenClassContext.Provider>
   );
 };
@@ -42,12 +53,16 @@ ScreenClassProvider.propTypes = {
    * Screen class to use when it cannot be determined otherwise.
    * Useful for server side rendering.
    */
-  fallbackScreenClass: PropTypes.oneOf([null, 'xs', 'sm', 'md', 'lg', 'xl', 'xxl' , 'xxxl']),
-};
-
-ScreenClassProvider.defaultProps = {
-  useOwnWidth: false,
-  fallbackScreenClass: null,
+  fallbackScreenClass: PropTypes.oneOf([
+    null,
+    "xs",
+    "sm",
+    "md",
+    "lg",
+    "xl",
+    "xxl",
+    "xxxl",
+  ]),
 };
 
 export default ScreenClassProvider;

--- a/src/grid/Col/index.js
+++ b/src/grid/Col/index.js
@@ -1,61 +1,71 @@
-import React, { createElement } from 'react';
-import PropTypes from 'prop-types';
-import getStyle from './style';
-import { getConfiguration } from '../../config';
-import { GutterWidthContext } from '../Row';
-import ScreenClassResolver from '../../context/ScreenClassResolver';
-import { Div } from '../../primitives';
+import React, { createElement } from "react";
+import PropTypes from "prop-types";
+import getStyle from "./style";
+import { getConfiguration } from "../../config";
+import { GutterWidthContext } from "../Row";
+import ScreenClassResolver from "../../context/ScreenClassResolver";
+import { Div } from "../../primitives";
 
-const Col = React.forwardRef(({
-  children,
-  xs,
-  sm,
-  md,
-  lg,
-  xl,
-  xxl,
-  xxxl,
-  offset,
-  pull,
-  push,
-  order,
-  debug,
-  style,
-  component,
-  width,
-  ...otherProps
-}, ref) => (
-  <ScreenClassResolver>
-    {(screenClass) => (
-      <GutterWidthContext.Consumer>
-        {(gutterWidth) => {
-          const theStyle = getStyle({
-            forceWidth: width,
-            width: {
-              xs,
-              sm,
-              md,
-              lg,
-              xl,
-              xxl,
-              xxxl,
-            },
-            offset,
-            pull,
-            push,
-            order,
-            debug,
-            screenClass,
-            gutterWidth,
-            gridColumns: getConfiguration().gridColumns,
-            moreStyle: style,
-          });
-          return createElement(component, { ref, style: theStyle, ...otherProps, children });
-        }}
-      </GutterWidthContext.Consumer>
-    )}
-  </ScreenClassResolver>
-));
+const Col = React.forwardRef(
+  (
+    {
+      children = null,
+      xs = null,
+      sm = null,
+      md = null,
+      lg = null,
+      xl = null,
+      xxl = null,
+      xxxl = null,
+      offset = {},
+      pull = {},
+      push = {},
+      order = {},
+      debug = false,
+      style = {},
+      component = Div,
+      width = null,
+      ...otherProps
+    },
+    ref
+  ) => (
+    <ScreenClassResolver>
+      {(screenClass) => (
+        <GutterWidthContext.Consumer>
+          {(gutterWidth) => {
+            const theStyle = getStyle({
+              forceWidth: width,
+              width: {
+                xs,
+                sm,
+                md,
+                lg,
+                xl,
+                xxl,
+                xxxl,
+              },
+              offset,
+              pull,
+              push,
+              order,
+              debug,
+              screenClass,
+              gutterWidth,
+              gridColumns: getConfiguration().gridColumns,
+              moreStyle: style,
+            });
+            return createElement(component, {
+              ref,
+              style: theStyle,
+              ...otherProps,
+              children,
+            });
+          }}
+        </GutterWidthContext.Consumer>
+      )}
+    </ScreenClassResolver>
+  )
+);
 
 Col.propTypes = {
   /**
@@ -65,59 +75,35 @@ Col.propTypes = {
   /**
    * The width of the column for screenclass `xs`, either a number between 0 and 12, or "content"
    */
-  xs: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.oneOf(['content']),
-  ]),
+  xs: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(["content"])]),
   /**
    * The width of the column for screenclass `sm`, either a number between 0 and 12, or "content"
    */
-  sm: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.oneOf(['content']),
-  ]),
+  sm: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(["content"])]),
   /**
    * The width of the column for screenclass `md`, either a number between 0 and 12, or "content"
    */
-  md: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.oneOf(['content']),
-  ]),
+  md: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(["content"])]),
   /**
    * The width of the column for screenclass `lg`, either a number between 0 and 12, or "content"
    */
-  lg: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.oneOf(['content']),
-  ]),
+  lg: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(["content"])]),
   /**
    * The width of the column for screenclass `xl`, either a number between 0 and 12, or "content"
    */
-  xl: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.oneOf(['content']),
-  ]),
+  xl: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(["content"])]),
   /**
    * The width of the column for screenclass `xxl`, either a number between 0 and 12, or "content"
    */
-  xxl: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.oneOf(['content']),
-  ]),
+  xxl: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(["content"])]),
   /**
    * The width of the column for screenclass `xxl`, either a number between 0 and 12, or "content"
    */
-  xxxl: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.oneOf(['content']),
-  ]),
+  xxxl: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(["content"])]),
   /**
    * A fixed width of the column for all screenclasses"
    */
-  width: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.string,
-  ]),
+  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
    * The offset of this column for all screenclasses
    */
@@ -169,7 +155,9 @@ Col.propTypes = {
   /**
    * Optional styling
    */
-  style: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+  style: PropTypes.objectOf(
+    PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  ),
   /**
    * Set to apply some debug styling
    */
@@ -178,25 +166,6 @@ Col.propTypes = {
    * Use your own component
    */
   component: PropTypes.elementType,
-};
-
-Col.defaultProps = {
-  children: null,
-  xs: null,
-  sm: null,
-  md: null,
-  lg: null,
-  xl: null,
-  xxl: null,
-  xxxl: null,
-  width: null,
-  offset: {},
-  push: {},
-  pull: {},
-  style: {},
-  order: {},
-  debug: false,
-  component: Div,
 };
 
 Col.displayName = "Col";

--- a/src/grid/Container/index.js
+++ b/src/grid/Container/index.js
@@ -1,49 +1,56 @@
-import React, { createElement } from 'react';
-import PropTypes from 'prop-types';
-import getStyle from './style';
-import { getConfiguration } from '../../config';
-import ScreenClassResolver from '../../context/ScreenClassResolver';
-import { Div } from '../../primitives';
+import React, { createElement } from "react";
+import PropTypes from "prop-types";
+import getStyle from "./style";
+import { getConfiguration } from "../../config";
+import ScreenClassResolver from "../../context/ScreenClassResolver";
+import { Div } from "../../primitives";
 
-const Container = React.forwardRef(({
-  children,
-  fluid,
-  xs,
-  sm,
-  md,
-  lg,
-  xl,
-  xxl,
-  xxxl,
-  style,
-  component,
-  ...otherProps
-}, ref) => (
-  <ScreenClassResolver>
-    {(screenClass) => createElement(
-      component,
-      {
-        ref,
-        style: getStyle({
-          fluid,
-          xs,
-          sm,
-          md,
-          lg,
-          xl,
-          xxl,
-          xxxl,
-          screenClass,
-          containerWidths: getConfiguration().containerWidths,
-          gutterWidth: getConfiguration().gutterWidth,
-          moreStyle: style,
-        }),
-        ...otherProps,
-      },
+const Container = React.forwardRef(
+  (
+    {
       children,
-    )}
-  </ScreenClassResolver>
-));
+      fluid = false,
+      xs = false,
+      sm = false,
+      md = false,
+      lg = false,
+      xl = false,
+      xxl = false,
+      xxxl = false,
+      style = {},
+      component = Div,
+      ...otherProps
+    },
+    ref
+  ) => (
+    <ScreenClassResolver>
+      {(screenClass) =>
+        createElement(
+          component,
+          {
+            ref,
+            style: getStyle({
+              fluid,
+              xs,
+              sm,
+              md,
+              lg,
+              xl,
+              xxl,
+              xxxl,
+              screenClass,
+              containerWidths: getConfiguration().containerWidths,
+              gutterWidth: getConfiguration().gutterWidth,
+              moreStyle: style,
+            }),
+            ...otherProps,
+          },
+          children
+        )
+      }
+    </ScreenClassResolver>
+  )
+);
 
 Container.propTypes = {
   /**
@@ -92,24 +99,13 @@ Container.propTypes = {
   /**
    * Optional styling
    */
-  style: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+  style: PropTypes.objectOf(
+    PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  ),
   /**
    * Use your own component
    */
   component: PropTypes.elementType,
-};
-
-Container.defaultProps = {
-  fluid: false,
-  xs: false,
-  sm: false,
-  md: false,
-  lg: false,
-  xl: false,
-  xxl: false,
-  xxxl: false,
-  style: {},
-  component: Div,
 };
 
 Container.displayName = "Container";

--- a/src/grid/Row/index.js
+++ b/src/grid/Row/index.js
@@ -1,44 +1,49 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { getConfiguration } from '../../config';
-import getStyle from './style';
-import { Div } from '../../primitives';
+import React from "react";
+import PropTypes from "prop-types";
+import { getConfiguration } from "../../config";
+import getStyle from "./style";
+import { Div } from "../../primitives";
 
 export const GutterWidthContext = React.createContext(false);
 
-const Row = React.forwardRef(({
-  children,
-  style,
-  align,
-  justify,
-  wrap,
-  debug,
-  nogutter,
-  gutterWidth,
-  component,
-  direction,
-  ...otherProps
-}, ref) => {
-  let theGutterWidth = getConfiguration().gutterWidth;
-  if (nogutter) theGutterWidth = 0;
-  if (typeof gutterWidth === 'number') theGutterWidth = gutterWidth;
-  const theStyle = getStyle({
-    gutterWidth: theGutterWidth,
-    align,
-    justify,
-    debug,
-    moreStyle: style,
-    direction,
-    wrap
-  });
-  return React.createElement(
-    component,
-    { ref, style: theStyle, ...otherProps },
-    <GutterWidthContext.Provider value={theGutterWidth}>
-      {children}
-    </GutterWidthContext.Provider>,
-  );
-});
+const Row = React.forwardRef(
+  (
+    {
+      children,
+      style = {},
+      align = "normal",
+      justify = "start",
+      wrap = "wrap",
+      debug = false,
+      nogutter = false,
+      gutterWidth = null,
+      component = Div,
+      direction = "row",
+      ...otherProps
+    },
+    ref
+  ) => {
+    let theGutterWidth = getConfiguration().gutterWidth;
+    if (nogutter) theGutterWidth = 0;
+    if (typeof gutterWidth === "number") theGutterWidth = gutterWidth;
+    const theStyle = getStyle({
+      gutterWidth: theGutterWidth,
+      align,
+      justify,
+      debug,
+      moreStyle: style,
+      direction,
+      wrap,
+    });
+    return React.createElement(
+      component,
+      { ref, style: theStyle, ...otherProps },
+      <GutterWidthContext.Provider value={theGutterWidth}>
+        {children}
+      </GutterWidthContext.Provider>
+    );
+  }
+);
 
 Row.propTypes = {
   /**
@@ -48,27 +53,32 @@ Row.propTypes = {
   /**
    * Vertical column alignment
    */
-  align: PropTypes.oneOf(['normal', 'start', 'center', 'end', 'stretch']),
+  align: PropTypes.oneOf(["normal", "start", "center", "end", "stretch"]),
   /**
    * Horizontal column alignment
    */
   justify: PropTypes.oneOf([
-    'start',
-    'center',
-    'end',
-    'between',
-    'around',
-    'initial',
-    'inherit',
+    "start",
+    "center",
+    "end",
+    "between",
+    "around",
+    "initial",
+    "inherit",
   ]),
   /**
    * flex-direction style attribute
    */
-  direction: PropTypes.oneOf(['column', 'row', 'column-reverse', 'row-reverse']),
+  direction: PropTypes.oneOf([
+    "column",
+    "row",
+    "column-reverse",
+    "row-reverse",
+  ]),
   /**
    * flex-wrap style attribute
    */
-  wrap: PropTypes.oneOf(['nowrap', 'wrap', 'reverse']),
+  wrap: PropTypes.oneOf(["nowrap", "wrap", "reverse"]),
   /**
    * No gutter for this row
    */
@@ -81,7 +91,7 @@ Row.propTypes = {
    * Optional styling
    */
   style: PropTypes.objectOf(
-    PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    PropTypes.oneOfType([PropTypes.number, PropTypes.string])
   ),
   /**
    * Set to apply some debug styling
@@ -90,19 +100,7 @@ Row.propTypes = {
   /**
    * Use your own component
    */
-  component: PropTypes.elementType
-};
-
-Row.defaultProps = {
-  align: 'normal',
-  justify: 'start',
-  direction: 'row',
-  wrap: 'wrap',
-  nogutter: false,
-  gutterWidth: null,
-  style: {},
-  debug: false,
-  component: Div,
+  component: PropTypes.elementType,
 };
 
 Row.displayName = "Row";

--- a/src/utilities/Hidden/index.js
+++ b/src/utilities/Hidden/index.js
@@ -1,31 +1,33 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import * as style from './style';
-import ScreenClassResolver from '../../context/ScreenClassResolver';
+import React from "react";
+import PropTypes from "prop-types";
+import * as style from "./style";
+import ScreenClassResolver from "../../context/ScreenClassResolver";
 
 const Hidden = ({
   children,
-  xs,
-  sm,
-  md,
-  lg,
-  xl,
-  xxl,
-  xxxl,
+  xs = false,
+  sm = false,
+  md = false,
+  lg = false,
+  xl = false,
+  xxl = false,
+  xxxl = false,
 }) => (
   <ScreenClassResolver>
-    {(screenClass) => (style.hidden({
-      screenClass,
-      xs,
-      sm,
-      md,
-      lg,
-      xl,
-      xxl,
-      xxxl,
-    })
-      ? null
-      : children)}
+    {(screenClass) =>
+      style.hidden({
+        screenClass,
+        xs,
+        sm,
+        md,
+        lg,
+        xl,
+        xxl,
+        xxxl,
+      })
+        ? null
+        : children
+    }
   </ScreenClassResolver>
 );
 
@@ -62,16 +64,6 @@ Hidden.propTypes = {
    * Hide on xxxlarge devices
    */
   xxxl: PropTypes.bool,
-};
-
-Hidden.defaultProps = {
-  xs: false,
-  sm: false,
-  md: false,
-  lg: false,
-  xl: false,
-  xxl: false,
-  xxxl: false,
 };
 
 export default Hidden;

--- a/src/utilities/Visible/index.js
+++ b/src/utilities/Visible/index.js
@@ -1,31 +1,33 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import * as style from './style';
-import ScreenClassResolver from '../../context/ScreenClassResolver';
+import React from "react";
+import PropTypes from "prop-types";
+import * as style from "./style";
+import ScreenClassResolver from "../../context/ScreenClassResolver";
 
 const Visible = ({
   children,
-  xs,
-  sm,
-  md,
-  lg,
-  xl,
-  xxl,
-  xxxl,
+  xs = false,
+  sm = false,
+  md = false,
+  lg = false,
+  xl = false,
+  xxl = false,
+  xxxl = false,
 }) => (
   <ScreenClassResolver>
-    {(screenClass) => (!style.visible({
-      screenClass,
-      xs,
-      sm,
-      md,
-      lg,
-      xl,
-      xxl,
-      xxxl,
-    })
-      ? null
-      : children)}
+    {(screenClass) =>
+      !style.visible({
+        screenClass,
+        xs,
+        sm,
+        md,
+        lg,
+        xl,
+        xxl,
+        xxxl,
+      })
+        ? null
+        : children
+    }
   </ScreenClassResolver>
 );
 
@@ -62,16 +64,6 @@ Visible.propTypes = {
    * Show on xxxlarge devices
    */
   xxxl: PropTypes.bool,
-};
-
-Visible.defaultProps = {
-  xs: false,
-  sm: false,
-  md: false,
-  lg: false,
-  xl: false,
-  xxl: false,
-  xxxl: false,
 };
 
 export default Visible;


### PR DESCRIPTION
## Overview
This PR addresses the upcoming deprecation of `defaultProps` in function components as signaled by React's warning: "Warning: ScreenClassProvider: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead." The changes involve updating the `ScreenClassProvider`, `Col`, `Container`, `Row`, `Hidden`, and `Visible` components within the `react-grid-system` library to use default function parameters for props instead of relying on `defaultProps`. This update ensures forward compatibility with future versions of React and adheres to modern JavaScript best practices.

## Changes
- **ScreenClassProvider**: Default parameters are set directly in the function signature for `useOwnWidth`, `children`, and `fallbackScreenClass`.
- **Col**: Introduced default function parameters for all props, ensuring any undefined props fall back to their intended defaults.
- **Container**: Updated to use default parameters, particularly for the `fluid` and `style` props, aligning with React's functional component recommendations.
- **Row**: Adjusted to define default values for `style`, `align`, `justify`, `wrap`, `debug`, `nogutter`, `gutterWidth`, `component`, and `direction` directly in the function signature.
- **Hidden** and **Visible**: Both components now use default parameters to manage visibility across various screen classes.

## Rationale
React is moving away from `defaultProps` in function components in favor of default function parameters, a more standard JavaScript approach. This change aligns `react-grid-system` with the latest React best practices and prepares it for future React versions. Furthermore, it simplifies the component code by leveraging default function parameters, which are more concise and easier to read.

## Testing
The modifications were tested to ensure they don't alter the existing behavior of the `react-grid-system`. Components continue to function correctly with default props as expected, and the console warning about `defaultProps` deprecation is resolved.

I look forward to any feedback or suggestions for further improvement.
